### PR TITLE
Add colon to commands in HELP view.

### DIFF
--- a/lib/Commands/AbstractCommand.php
+++ b/lib/Commands/AbstractCommand.php
@@ -60,7 +60,7 @@ abstract class AbstractCommand {
 	protected function getHelp() {
 		$result = "*HELP*\n";
 		foreach ($this->helpCommands as $command => $helpText) {
-			$result .= "*{$this->commandName} {$command}*: {$helpText} \n";
+			$result .= "*{$this->commandName}:{$command}*: {$helpText} \n";
 		}
 		return $result;
 	}


### PR DESCRIPTION
That should fix the issue that the help command writes something  like "review merged" instead of "review:merged" with colon.