### PR TITLE
[BUGFIX] Auto restart botty after crashing

### DIFF
--- a/Resources/Privat/Scripts/botty.sh
+++ b/Resources/Privat/Scripts/botty.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+######################################################
+#
+# T3Bot
+#
+# @author Simon Gilli <typo3@gilbertsoft.org>
+#
+# @link http://www.t3bot.de
+# @link http://wiki.typo3.org/T3Bot
+#
+# @param NAME
+# @param PID file
+# @param LOG file
+# @param DAEMON file
+# @param DAEMON options
+#
+######################################################
+
+
+# Read arguments and shift to get access to all options
+NAME=$1
+PIDFILE=$2
+LOGFILE=$3
+DAEMON=$4
+
+shift 4
+
+# Test arguments
+test -n $NAME || exit 0
+test -f $PIDFILE || exit 0
+test -x $DAEMON || exit 0
+test -n $@ || exit 0
+
+# Loop while PID file exists
+while [ -f $PIDFILE ]
+do
+    "$DAEMON" $@
+    echo "$NAME restored" >> $LOGFILE
+done
+
+echo "$NAME has terminated" >> $LOGFILE
+
+exit 0

--- a/Resources/Privat/Scripts/daemon.sh
+++ b/Resources/Privat/Scripts/daemon.sh
@@ -30,12 +30,14 @@ LOGFILE="/var/log/${NAME}.log"
 # CHANGE this to your PHP path
 DAEMON="/usr/bin/php"
 # CHANGE this to your bot path
+DAEMON_HELPER="/var/www/t3bot.de/botty.sh"
 DAEMON_OPTS="/var/www/t3bot.de/botty.php"
 
-START_OPTS="--start --background --make-pidfile --pidfile ${PIDFILE} --exec ${DAEMON} ${DAEMON_OPTS}"
+START_OPTS="--start --background --make-pidfile --pidfile ${PIDFILE} --exec ${DAEMON_HELPER} ${NAME} ${PIDFILE} ${DAEMON} ${DAEMON_OPTS}"
 STOP_OPTS="--stop --pidfile ${PIDFILE}"
 
 test -x $DAEMON || exit 0
+test -x $DAEMON_HELPER || exit 0
 
 set -e
 


### PR DESCRIPTION
This script tries to catch the situation when the PHP scripts crashes and the daemon must be restarted afterwards manually by introducing another loop directly in bash. The loop will be terminated after the PIDFILE was deleted by the calling the stop action.

Solves #13

@NeoBlack/T3Bot please review this pull request